### PR TITLE
Add target `es2022`

### DIFF
--- a/src/components/Configuration.tsx
+++ b/src/components/Configuration.tsx
@@ -210,6 +210,7 @@ export default function Configuration() {
               <option value="es2019">ES2019</option>
               <option value="es2020">ES2020</option>
               <option value="es2021">ES2021</option>
+              <option value="es2022">ES2022</option>
             </Select>
           </FormControl>
           <FormControl>

--- a/src/swc.ts
+++ b/src/swc.ts
@@ -76,6 +76,7 @@ export type EsVersion =
   | 'es2019'
   | 'es2020'
   | 'es2021'
+  | 'es2022'
 
 export type ModuleOptions =
   | {
@@ -364,6 +365,7 @@ export const configSchema: JSONSchema6 = {
             'es2019',
             'es2020',
             'es2021',
+            'es2022',
           ],
         },
         loose: { type: 'boolean' },


### PR DESCRIPTION
Some proposals that will be included in ES2022 have been implements in SWC already. So I think it makes sense to have es2022 as the target of the playground.