### PR TITLE
fix: replace useSpread with useBuiltIns

### DIFF
--- a/src/swc.ts
+++ b/src/swc.ts
@@ -191,7 +191,7 @@ export interface TransformOptions {
     pragmaFrag?: string
     throwIfNamespace?: boolean
     development?: boolean
-    useSpread?: boolean
+    useBuiltins?: boolean
     refresh?: {
       refreshReg?: string
       refreshSig?: string
@@ -558,7 +558,7 @@ export const configSchema: JSONSchema6 = {
                 pragmaFrag: { type: 'string' },
                 throwIfNamespace: { type: 'boolean' },
                 development: { type: 'boolean' },
-                useSpread: { type: 'boolean' },
+                useBuiltins: { type: 'boolean' },
                 refresh: {
                   type: 'object',
                   properties: {


### PR DESCRIPTION
Add support for https://github.com/swc-project/website/blob/master/pages/docs/configuration/compilation.md#jsctransformreactusebuiltins which I _think_ must have replaced `useSpread`, an option I see no documentation for or mention of in https://github.com/search?q=org%3Aswc-project+useSpread&type=code except that it seems to be some removed option.