### PR TITLE
Stripping ANSI to fix ugly error format

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-dom": "^18.1.0",
     "react-icons": "^4.3.1",
     "semver": "^7.3.7",
+    "strip-ansi": "^7.0.1",
     "swr": "^1.3.0",
     "ts-results": "^3.3.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,7 @@ specifiers:
   react-dom: ^18.1.0
   react-icons: ^4.3.1
   semver: ^7.3.7
+  strip-ansi: ^7.0.1
   swr: ^1.3.0
   ts-node: ^10.8.0
   ts-results: ^3.3.0
@@ -47,6 +48,7 @@ dependencies:
   react-dom: 18.1.0_react@18.1.0
   react-icons: 4.3.1_react@18.1.0
   semver: 7.3.7
+  strip-ansi: 7.0.1
   swr: 1.3.0_react@18.1.0
   ts-results: 3.3.0
 
@@ -1442,6 +1444,11 @@ packages:
   /ansi-regex/5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
+
+  /ansi-regex/6.0.1:
+    resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
+    engines: {node: '>=12'}
+    dev: false
 
   /ansi-styles/3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -3104,6 +3111,13 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
+
+  /strip-ansi/7.0.1:
+    resolution: {integrity: sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==}
+    engines: {node: '>=12'}
+    dependencies:
+      ansi-regex: 6.0.1
+    dev: false
 
   /strip-bom/3.0.0:
     resolution: {integrity: sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=}

--- a/src/components/OutputEditor.tsx
+++ b/src/components/OutputEditor.tsx
@@ -14,7 +14,7 @@ import type {
   TransformationOutput,
   TransformationResult,
 } from '../swc'
-import stripAnsi from 'strip-ansi';
+import stripAnsi from 'strip-ansi'
 
 function isTransformedCode(value: unknown): value is TransformationOutput {
   return typeof (value as TransformationOutput).code === 'string'

--- a/src/components/OutputEditor.tsx
+++ b/src/components/OutputEditor.tsx
@@ -14,6 +14,7 @@ import type {
   TransformationOutput,
   TransformationResult,
 } from '../swc'
+import stripAnsi from 'strip-ansi';
 
 function isTransformedCode(value: unknown): value is TransformationOutput {
   return typeof (value as TransformationOutput).code === 'string'
@@ -21,7 +22,7 @@ function isTransformedCode(value: unknown): value is TransformationOutput {
 
 function stringifyOutput(output: TransformationResult | ParserResult): string {
   if (output.err) {
-    return output.val
+    return stripAnsi(output.val)
   } else if (isTransformedCode(output.val)) {
     return output.val.code
   } else {
@@ -39,6 +40,7 @@ const editorOptions: editor.IStandaloneEditorConstructionOptions = {
   ...sharedEditorOptions,
   readOnly: true,
   wordWrap: 'on',
+  renderControlCharacters: false,
   tabSize: 4, // this aligns with swc
 }
 


### PR DESCRIPTION
Since SWC adopted Miette, the error formatting in the playground renders unescaped control chars and ANSI encoding. I attempted to render the nice ANSI colors but Monaco editor suprisignly [does not support this](https://github.com/microsoft/vscode/issues/38834), so I opted to just strip out ANSI. 

Before:
<img width="436" alt="Screen Shot 2022-05-27 at 11 49 32 AM" src="https://user-images.githubusercontent.com/7434954/170772939-a7595d35-16db-4496-bd2c-635c2de487c5.png">

After:
<img width="411" alt="Screen Shot 2022-05-27 at 11 52 35 AM" src="https://user-images.githubusercontent.com/7434954/170773001-bc775695-6f3e-463a-b0bc-5341e8ac2c69.png">
