### PR TITLE
FIX: Add maximum character limit to shared code parameter to URL

### DIFF
--- a/src/components/InputEditor.tsx
+++ b/src/components/InputEditor.tsx
@@ -32,6 +32,10 @@ function getIssueReportUrl({
   const reportUrl = new URL(
     `https://github.com/swc-project/swc/issues/new?assignees=&labels=C-bug&template=bug_report.yml`
   )
+  if (code.length > 2000)
+    code =
+      'Your input is too large to share. Please copy the code and paste it in the issue.'
+
   reportUrl.searchParams.set('code', code)
   reportUrl.searchParams.set('config', JSON.stringify(config, null, 2))
   reportUrl.searchParams.set('repro-link', playgroundLink)
@@ -109,7 +113,7 @@ export default function InputEditor({ output }: Props) {
   const shareUrl = useMemo(() => {
     const url = new URL(location.href)
     url.searchParams.set('version', swcVersion)
-    const encodedInput = Base64.fromUint8Array(gzip(code))
+    let encodedInput = Base64.fromUint8Array(gzip(code))
     url.searchParams.set('code', encodedInput)
     const encodedConfig = Base64.fromUint8Array(gzip(JSON.stringify(swcConfig)))
     url.searchParams.set('config', encodedConfig)

--- a/src/components/InputEditor.tsx
+++ b/src/components/InputEditor.tsx
@@ -190,10 +190,6 @@ export default function InputEditor({ output }: Props) {
           <Button
             size="xs"
             leftIcon={<CgFileDocument />}
-            // as="a"
-            // href={issueReportUrl}
-            // target="_blank"
-            // rel="noopener"
             onClick={handleIssueReportClick}
           >
             Report Issue

--- a/src/components/InputEditor.tsx
+++ b/src/components/InputEditor.tsx
@@ -33,7 +33,7 @@ function getIssueReportUrl({
     `https://github.com/swc-project/swc/issues/new?assignees=&labels=C-bug&template=bug_report.yml`
   )
 
-  reportUrl.searchParams.set('code', code.length > 2000 ? '' : code)
+  reportUrl.searchParams.set('code', code)
   reportUrl.searchParams.set('config', JSON.stringify(config, null, 2))
   reportUrl.searchParams.set('repro-link', playgroundLink)
   reportUrl.searchParams.set('version', version)
@@ -129,8 +129,6 @@ export default function InputEditor({ output }: Props) {
   )
 
   const handleIssueReportClick = () => {
-    window.open(issueReportUrl, '_blank')
-
     if (code.length > 2000) {
       toast({
         title: 'Code too long',
@@ -142,6 +140,7 @@ export default function InputEditor({ output }: Props) {
       })
       return
     }
+    window.open(issueReportUrl, '_blank')
   }
 
   const handleShare = async () => {

--- a/src/components/InputEditor.tsx
+++ b/src/components/InputEditor.tsx
@@ -113,7 +113,7 @@ export default function InputEditor({ output }: Props) {
   const shareUrl = useMemo(() => {
     const url = new URL(location.href)
     url.searchParams.set('version', swcVersion)
-    let encodedInput = Base64.fromUint8Array(gzip(code))
+    const encodedInput = Base64.fromUint8Array(gzip(code))
     url.searchParams.set('code', encodedInput)
     const encodedConfig = Base64.fromUint8Array(gzip(JSON.stringify(swcConfig)))
     url.searchParams.set('config', encodedConfig)

--- a/src/components/InputEditor.tsx
+++ b/src/components/InputEditor.tsx
@@ -32,11 +32,8 @@ function getIssueReportUrl({
   const reportUrl = new URL(
     `https://github.com/swc-project/swc/issues/new?assignees=&labels=C-bug&template=bug_report.yml`
   )
-  if (code.length > 2000)
-    code =
-      'Your input is too large to share. Please copy the code and paste it in the issue.'
 
-  reportUrl.searchParams.set('code', code)
+  reportUrl.searchParams.set('code', code.length > 2000 ? '' : code)
   reportUrl.searchParams.set('config', JSON.stringify(config, null, 2))
   reportUrl.searchParams.set('repro-link', playgroundLink)
   reportUrl.searchParams.set('version', version)
@@ -131,6 +128,22 @@ export default function InputEditor({ output }: Props) {
     [code, swcConfig, swcVersion, shareUrl]
   )
 
+  const handleIssueReportClick = () => {
+    window.open(issueReportUrl, '_blank')
+
+    if (code.length > 2000) {
+      toast({
+        title: 'Code too long',
+        description:
+          'Your input is too large to share. Please copy the code and paste it into the issue.',
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      })
+      return
+    }
+  }
+
   const handleShare = async () => {
     if (!navigator.clipboard) {
       toast({
@@ -178,10 +191,11 @@ export default function InputEditor({ output }: Props) {
           <Button
             size="xs"
             leftIcon={<CgFileDocument />}
-            as="a"
-            href={issueReportUrl}
-            target="_blank"
-            rel="noopener"
+            // as="a"
+            // href={issueReportUrl}
+            // target="_blank"
+            // rel="noopener"
+            onClick={handleIssueReportClick}
           >
             Report Issue
           </Button>


### PR DESCRIPTION
## Problem

- When user has a long code and tries to report an issue, GitHub throws a `bad request` error.

![image](https://user-images.githubusercontent.com/10114716/185634369-2f9cfd18-16fc-4673-8167-e81d7b26c6d0.png)


## Solution
- When a user tries to share a long code example, then will see the message. `Your input is too large to share. Please copy the code and paste it into the issue.`
